### PR TITLE
Allow array of strings for dateStrings 

### DIFF
--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -115,7 +115,7 @@ declare namespace Connection {
          * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript Date
          * objects. (Default: false)
          */
-        dateStrings?: boolean;
+        dateStrings?: boolean | Array<'TIMESTAMP' | 'DATETIME' | 'DATE'>;
 
         /**
          * This will print all incoming and outgoing packets on stdout.

--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -113,7 +113,9 @@ declare namespace Connection {
 
         /**
          * Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript Date
-         * objects. (Default: false)
+         * objects. Can be true/false or an array of type names to keep as strings.
+         *
+         * (Default: false)
          */
         dateStrings?: boolean | Array<'TIMESTAMP' | 'DATETIME' | 'DATE'>;
 


### PR DESCRIPTION
According to https://github.com/mysqljs/mysql#connection-options the option `dateStrings` also accepts an array of type names:

> `dateStrings`: Force date types (TIMESTAMP, DATETIME, DATE) to be returned as strings rather then inflated into JavaScript Date objects. Can be `true`/`false` or an array of type names to keep as strings. (Default: `false`)