### PR TITLE
Adding the type `ResultSetHeader` to the `query` types.

### DIFF
--- a/lib/Connection.d.ts
+++ b/lib/Connection.d.ts
@@ -1,6 +1,6 @@
 
 import Query = require('./protocol/sequences/Query');
-import {OkPacket, FieldPacket, RowDataPacket} from './protocol/packets/index';
+import {OkPacket, FieldPacket, RowDataPacket, ResultSetHeader} from './protocol/packets/index';
 import {EventEmitter} from 'events';
 
 declare namespace Connection {
@@ -197,8 +197,8 @@ declare class Connection extends EventEmitter {
     config: Connection.ConnectionOptions;
     threadId: number;
 
-    static createQuery<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
-    static createQuery<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    static createQuery<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    static createQuery<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
 
     beginTransaction(callback: (err: Query.QueryError | null) => void): void;
 
@@ -208,10 +208,10 @@ declare class Connection extends EventEmitter {
 
     changeUser(options: Connection.ConnectionOptions, callback?: (err: Query.QueryError | null) => void): void;
 
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: Query.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
 
     end(callback?: (err: Query.QueryError | null) => void): void;
     end(options: any, callback?: (err: Query.QueryError | null) => void): void;

--- a/lib/Pool.d.ts
+++ b/lib/Pool.d.ts
@@ -1,6 +1,6 @@
 
 import Query = require('./protocol/sequences/Query');
-import {OkPacket, RowDataPacket, FieldPacket} from './protocol/packets/index';
+import {OkPacket, RowDataPacket, FieldPacket, ResultSetHeader} from './protocol/packets/index';
 import Connection = require('./Connection');
 import PoolConnection = require('./PoolConnection');
 import {EventEmitter} from 'events';
@@ -51,10 +51,10 @@ declare class Pool extends EventEmitter {
 
     getConnection(callback: (err: NodeJS.ErrnoException, connection: PoolConnection) => any): void;
 
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;
-    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[]>(options: Query.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;
+    query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
 
     end(callback?: (err: NodeJS.ErrnoException | null, ...args: any[]) => any): void;
 


### PR DESCRIPTION
This PR is related to the last PR I requested. Last time, I added the type `ResultSetHeader`.  This time, I am adding it to the `query` methods that can use them.